### PR TITLE
Data Loss Problem if new line is in data

### DIFF
--- a/lib/logstash/codecs/rfc6587.rb
+++ b/lib/logstash/codecs/rfc6587.rb
@@ -61,7 +61,7 @@ class LogStash::Codecs::Rfc6587 < LogStash::Codecs::Base
     end
 
     to_read = header.to_i
-    line = data.gets(to_read)
+    line = data.read(to_read)
 
     if not line
       @leftover = header


### PR DESCRIPTION
If a new line exists in data, a problem occurs because the gets function returns only up to the new line. 

For example, when calling gets(5) for the string "5 12\n3410 12345678910", only the string "12\n" is returned. 
Only up to the string "5 12\n" is stored in the @leftover variable. 
When a new string "4 1234" is added, it is added to the existing remaining string (@leftover). 
Thus, "5 12\n4 1234" is created in data. 

For the added string, "5" is read as the header, gets(5) is called, and only the string "12\n" is returned. 
This process is repeated, resulting in data loss. 

This bug can be resolved by changing the gets function to a read function.